### PR TITLE
Tweaks to compiler build to improve dependency management

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ cases your OS will have a suitable package for these, but if not see the links p
 each item in the list.
 
 - GCC 11.4.0 or later
-- ghcup (Haskell 9.2.8 and cabal 3.12.1.0 or later) (see https://www.haskell.org/ghcup/install/#linux-ubuntu)
+- ghcup (Haskell 9.6.7 and cabal 3.12.1.0) (see https://www.haskell.org/ghcup/install/#linux-ubuntu)
 - Boost C++ library version 1.83.0 or later (see https://www.boost.org/)
 - CMake version 3.26 or later (see https://cmake.org/)
 - Ninja. It's not required to use Ninja; you can use any build tool supported by CMake, but we recommend Ninja for its speed and simplicity (see https://ninja-build.org/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@ cmake_minimum_required(VERSION 3.30)
 
 project(kanagawa LANGUAGES CXX)
 
-set(KANAGAWA_DIST_DIR "${CMAKE_BINARY_DIR}/dist")
-set(KANAGAWA_BIN_DIR "${KANAGAWA_DIST_DIR}/bin")
+set(KANAGAWA_EXE_NAME "kanagawa")
+# This can not be the same as KANAGAWA_EXE_NAME (CMake does not like it)
+set(KANAGAWA_SHARED_LIBRARY_NAME "kanagawa-backend")
 
 # Find all dependent libraries, headers, and tools.
 include(${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/deps.cmake)

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# kanagawac - The Kanagawa compiler back-end as a shared library.
+# kanagawa_lib - The Kanagawa compiler back-end as a shared library.
 # This library is linked with the front-end code to produce the final
 # kanagawa executable.
 
@@ -40,29 +40,34 @@ set(CPP_SOURCES
     verilog.cpp
 )
 
-add_library(kanagawac SHARED ${CPP_SOURCES})
+add_library(kanagawa_lib SHARED ${CPP_SOURCES})
 
-# target_compile_definitions(kanagawac PRIVATE KANAGAWA_SKIP_CONSISTENCY_CHECKS=1)
+# Change the actual library filename to "kanagawa.dll" on Windows, "libkanagawa.so" (on Linux), etc.
+set_target_properties(kanagawa_lib PROPERTIES
+    OUTPUT_NAME ${KANAGAWA_SHARED_LIBRARY_NAME}
+)
 
-target_include_directories(kanagawac PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# target_compile_definitions(kanagawa_lib PRIVATE KANAGAWA_SKIP_CONSISTENCY_CHECKS=1)
+
+target_include_directories(kanagawa_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Enable pre-compiled headers for faster builds
-target_precompile_headers(kanagawac PRIVATE [["pch.h"]])
+target_precompile_headers(kanagawa_lib PRIVATE [["pch.h"]])
 set_source_files_properties(platform.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 set_source_files_properties(stack_trace.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 
 # Despite the misleading name, this adds Boost to the include path using the information
 # gleaned from a call to find_package
-target_link_libraries(kanagawac PRIVATE Boost::headers)
+target_link_libraries(kanagawa_lib PRIVATE Boost::headers)
 
 # Make boost stack trace print function names in addition to addresses
-target_compile_definitions(kanagawac PRIVATE "BOOST_STACKTRACE_USE_ADDR2LINE")
+target_compile_definitions(kanagawa_lib PRIVATE "BOOST_STACKTRACE_USE_ADDR2LINE")
 
 # Link with pthread library for threading support
-target_link_libraries(kanagawac PRIVATE Threads::Threads)
+target_link_libraries(kanagawa_lib PRIVATE Threads::Threads)
 
 # Add CIRCT targets/library dependencies
-target_link_libraries(kanagawac PRIVATE
+target_link_libraries(kanagawa_lib PRIVATE
     CIRCTComb
     CIRCTCombTransforms
     CIRCTExportVerilog
@@ -179,15 +184,5 @@ target_link_libraries(kanagawac PRIVATE
 
 # Add CIRCT include directories
 get_target_property(CIRCT_INCLUDES CIRCTHW INCLUDE_DIRECTORIES)
-target_include_directories(kanagawac PUBLIC "${CIRCT_INCLUDES}")
+target_include_directories(kanagawa_lib PUBLIC "${CIRCT_INCLUDES}")
 
-file(MAKE_DIRECTORY ${KANAGAWA_BIN_DIR})
-
-add_custom_command(
-    TARGET kanagawac
-    POST_BUILD
-    COMMAND
-        ${CMAKE_COMMAND} -E copy_if_different
-        $<TARGET_FILE:kanagawac>
-        "${KANAGAWA_BIN_DIR}/"
-)

--- a/compiler/hs/CMakeLists.txt
+++ b/compiler/hs/CMakeLists.txt
@@ -3,43 +3,98 @@
 
 # kanagawa - The Kanagawa compiler executable.
 # This executable is built by building the front-end code using the Haskell build
-# tool cabal. It links the compiler back-end shared library (kanagawac).
+# tool cabal. It copies this executable and the dependent shared library into
+# a common folder.
+#
+# Projects that need to run the Kanagawa compiler can do this:
+#
+# # Ensure Kanagawa is built
+# add_dependencies(my_target kanagawa::exe)
+#
+# # Get the path to the Kanagawa executable and use it, with a dependency to make sure it's built
+# add_custom_command(
+#   COMMAND "$<TARGET_FILE:kanagawa::exe>" ...
+#   DEPENDS kanagawa::exe
+#   ...
+# )
 
 # Set the directory where cabal will be store intermediate files
-set(CABAL_WORKING_DIR ${CMAKE_BINARY_DIR}/kanagawa_temp)
+set(CABAL_WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR}/temp)
 file(MAKE_DIRECTORY ${CABAL_WORKING_DIR})
+
+#
+# Build the kanagawa exe using cabal
+
+# Where cabal will output the executable (a stable path)
+set(KANAGAWA_EXE_DIR "${CMAKE_BINARY_DIR}/kanagawa")
+set(KANAGAWA_EXE_DEST "${KANAGAWA_EXE_DIR}/kanagawa${CMAKE_EXECUTABLE_SUFFIX}")
+
+# This is needed to avoid generator expressions in OUTPUT
+set(KANAGAWA_LIB_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}${KANAGAWA_SHARED_LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+set(KANAGAWA_LIB_DEST "${KANAGAWA_EXE_DIR}/${KANAGAWA_LIB_NAME}")
+
+set(CABAL_OPTIONS
+    "--with-compiler=${GHC_EXE}"
+    "--extra-lib-dirs=$<TARGET_FILE_DIR:kanagawa_lib>"
+    "--builddir=${CABAL_WORKING_DIR}/dist"
+    "--logs-dir=${CABAL_WORKING_DIR}/logs"
+)
 
 # Get the Boost include directory path
 get_target_property(BOOST_INCLUDE_DIRS Boost::headers INTERFACE_INCLUDE_DIRECTORIES)
 
-set(CABAL_OPTIONS
-    "--with-compiler=${GHC_EXE}"
-    "--extra-lib-dirs=${CMAKE_BINARY_DIR}/compiler/cpp"
-    "--builddir=${CABAL_WORKING_DIR}/dist"
-    "--logs-dir=${CABAL_WORKING_DIR}/logs"
-    "--extra-include-dirs=${BOOST_INCLUDE_DIRS}"
-    "v2-build"
-    "exe:kanagawa"
-)
+foreach(_inc ${BOOST_INCLUDE_DIRS})
+  list(APPEND CABAL_OPTIONS "--extra-include-dirs=${_inc}")
+endforeach()
 
-add_custom_target(
-    kanagawa
-    ${CMAKE_COMMAND} -E env TMP=${CABAL_WORKING_DIR}
-    TEMP=${CABAL_WORKING_DIR} ${CABAL_EXE} ${CABAL_OPTIONS}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/compiler
-    VERBATIM
-)
-
-file(MAKE_DIRECTORY ${KANAGAWA_BIN_DIR})
-
+# Build the kanagwa executable and copy it to the dist/bin directory
 add_custom_command(
-    TARGET kanagawa
-    POST_BUILD
+    OUTPUT ${KANAGAWA_EXE_DEST}
+    COMMAND ${CMAKE_COMMAND} -E echo "Building kanagawa exe with Cabal"
+    COMMAND ${CMAKE_COMMAND} -E env
+        TMP=${CABAL_WORKING_DIR}
+        TEMP=${CABAL_WORKING_DIR}
+        ${CABAL_EXE} ${CABAL_OPTIONS} v2-build exe:kanagawa
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${KANAGAWA_EXE_DIR}"
     COMMAND
         ${CMAKE_COMMAND} -E copy_if_different
-        "${CABAL_WORKING_DIR}/dist/build/x86_64-linux/${GHC_NAME}/kanagawa-1.0.0/x/kanagawa/build/kanagawa/kanagawa"
-        "${KANAGAWA_BIN_DIR}/"
+        "${CABAL_WORKING_DIR}/dist/build/x86_64-linux/${GHC_NAME}/kanagawa-1.0.0/x/kanagawa/build/kanagawa/kanagawa${CMAKE_EXECUTABLE_SUFFIX}"
+        "${KANAGAWA_EXE_DEST}"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/compiler
+    DEPENDS kanagawa_lib
+    VERBATIM
+    USES_TERMINAL
 )
 
-# Ensure that kanagawac is built before kanagawa is built
-add_dependencies(kanagawa kanagawac)
+# Phony target representing presence of the exe file and the shared library
+add_custom_target(kanagawa_exe DEPENDS "${KANAGAWA_EXE_DEST}")
+
+# Copy the shared library next to the exe; re-runs whenever the lib changes
+add_custom_command(
+  OUTPUT "${KANAGAWA_LIB_DEST}"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${KANAGAWA_EXE_DIR}>"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "$<TARGET_FILE:kanagawa_lib>"
+          "$<SHELL_PATH:${KANAGAWA_LIB_DEST}>"
+  # Re-run when the actual built lib changes, and only after the exe exists (dir ready)
+  DEPENDS "$<TARGET_FILE:kanagawa_lib>" kanagawa_exe
+  VERBATIM
+  USES_TERMINAL
+)
+
+add_custom_target(kanagawa_lib_inplace
+  DEPENDS "${KANAGAWA_LIB_DEST}"
+)
+
+# Phony target that represents both the exe and the shared library
+add_custom_target(kanagawa_runtime)
+add_dependencies(kanagawa_runtime kanagawa_exe kanagawa_lib_inplace)
+
+# IMPORTED executable for convenient references. You can get the path to the exe with
+add_executable(kanagawa::exe IMPORTED GLOBAL)
+set_target_properties(kanagawa::exe PROPERTIES
+  IMPORTED_LOCATION "${KANAGAWA_EXE_DEST}"
+)
+
+# Make the imported exe depend on the build of the real exe (+ lib copy)
+add_dependencies(kanagawa::exe kanagawa_runtime)

--- a/compiler/kanagawa.cabal
+++ b/compiler/kanagawa.cabal
@@ -8,7 +8,7 @@ copyright:           (C) Microsoft
 category:            Language
 build-type:          Simple
 license:             MIT
-license-file:        LICENSE
+license-file:        ../LICENSE
 
 Flag Debug {
   Description: Debug build, don't optimize
@@ -46,9 +46,9 @@ executable kanagawa
   include-dirs:        cpp
 
   if os(linux)
-    extra-libraries:   kanagawac stdc++ dl
+    extra-libraries:   kanagawa-backend stdc++ dl
   else
-    extra-libraries:   kanagawac
+    extra-libraries:   kanagawa-backend
 
   if os(darwin)
       ld-options:      -Wl,-keep_dwarf_unwind
@@ -114,6 +114,6 @@ library
 
   default-language:    Haskell2010
 
-  -- add $ORIGIN to rpath, to enable libkanagawac.so to be found adjacent to the kanagawa compiler binary
+  -- add $ORIGIN to rpath, to enable libkanagawa-backend.so to be found adjacent to the kanagawa compiler binary
   if !os(windows)
       ld-options:      -Wl,-rpath,$ORIGIN


### PR DESCRIPTION
- Tweaks to compiler build to improve dependency management
- Provide a way for build targets that need to use the kanagawa compiler to easily locate the executable via CMake target property
- Switch Haskell version to updated version requested by Adam