### PR TITLE
Fix huge generated RTL file size in logic test, long_class_name, and re-enable the test

### DIFF
--- a/test/logic/CMakeLists.txt
+++ b/test/logic/CMakeLists.txt
@@ -31,7 +31,7 @@ set(LOGIC_TEST_SOURCES
     initializer_list.k
     lambda_test_cases.k
     last.k
-    # long_class_name.k # Disabled because it results in a 3.5GB SV file
+    long_class_name.k
     loop_test_cases_1.k
     loop_test_cases_2.k
     memory_test_cases_1.k

--- a/test/logic/long_class_name.k
+++ b/test/logic/long_class_name.k
@@ -43,5 +43,5 @@ private:
 
 inline void test_main()
 {
-    unit::test<1>(unit::fixture<helper<256>>());
+    unit::test<1>(unit::fixture<helper<4>>());
 }


### PR DESCRIPTION
Fix huge generated RTL file size in logic test, long_class_name, and re-enable the test.

The primary reason the file size was so large, other than the really long symbol names, is that there is a template parameter that sets the number of inner class instances there are, and this was set to 256. I don't really see that this large value improves test coverage, so I reduced it to 4. This change reduced the file size to 352KB

Closes: #14 