### PR TITLE
Ensure Kanagawa compiler is re-built and re-invoked after modifying a compiler source file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ set(KANAGAWA_EXE_NAME "kanagawa")
 # This can not be the same as KANAGAWA_EXE_NAME (CMake does not like it)
 set(KANAGAWA_SHARED_LIBRARY_NAME "kanagawa-backend")
 
+# List of targets which comprise kanagawa_runtime 
+set(KANAGAWA_RUNTIME_TARGETS
+    kanagawa_lib_inplace
+    kanagawa_lib
+    kanagawa_exe
+)
+
 # Find all dependent libraries, headers, and tools.
 include(${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/deps.cmake)
 

--- a/build/cmake/test_helper.cmake
+++ b/build/cmake/test_helper.cmake
@@ -93,7 +93,7 @@ function(add_kanagawa target)
             ${_ARG_SOURCES}
     COMMAND ${CMAKE_COMMAND} -E echo "Kanagawa HLS completed for '${target}'" > "${_stamp}"
     DEPENDS
-      "$<TARGET_FILE:kanagawa::exe>"
+      ${KANAGAWA_RUNTIME_TARGETS}
       ${_ARG_SOURCES}
       "${_inputs_file}"
     WORKING_DIRECTORY "${_ARG_WORKING_DIRECTORY}"
@@ -103,7 +103,7 @@ function(add_kanagawa target)
 
   # Phony target others can depend on
   add_custom_target(${target} DEPENDS "${_stamp}")
-  add_dependencies(${target} kanagawa::exe)
+  add_dependencies(${target} kanagawa_runtime)
 
   # Expose OUTPUT_DIR to caller
   set(${target}_OUTPUT_DIR "${_ARG_OUTPUT_DIR}" PARENT_SCOPE)
@@ -126,7 +126,7 @@ endfunction()
 #     [OUTPUT_DIR <dir>]
 #     [WORKING_DIRECTORY <dir>]
 #     [SIM_EXE_OUT_VAR <variable-name>]
-#     [DEPENDS <target-or-file> ...]]
+#     [DEPENDS <target-or-file> ...]
 #     TESTBENCH_MODULE <testbench-module-name>
 #     SOURCES <src1> [<src2> ...]
 #     [OPTIONS <opt1> <opt2> ...]

--- a/compiler/hs/CMakeLists.txt
+++ b/compiler/hs/CMakeLists.txt
@@ -9,12 +9,12 @@
 # Projects that need to run the Kanagawa compiler can do this:
 #
 # # Ensure Kanagawa is built
-# add_dependencies(my_target kanagawa::exe)
+# add_dependencies(my_target kanagawa_runtime)
 #
 # # Get the path to the Kanagawa executable and use it, with a dependency to make sure it's built
 # add_custom_command(
 #   COMMAND "$<TARGET_FILE:kanagawa::exe>" ...
-#   DEPENDS kanagawa::exe
+#   DEPENDS ${KANAGAWA_RUNTIME_TARGETS}
 #   ...
 # )
 
@@ -106,13 +106,15 @@ add_custom_target(kanagawa_lib_inplace
 
 # Phony target that represents both the exe and the shared library
 add_custom_target(kanagawa_runtime)
-add_dependencies(kanagawa_runtime kanagawa_exe kanagawa_lib_inplace)
+add_dependencies(kanagawa_runtime ${KANAGAWA_RUNTIME_TARGETS})
 
 # IMPORTED executable for convenient references. You can get the path to the exe with
+# $<TARGET_FILE:kanagawa::exe>
+# Note that a target should never depend on kanagawa::exe
+# because CMake does not know how to rebuild it
+# Instead, depend on kanagawa_runtime (for target level dependencies)
+# or ${KANAGAWA_RUNTIME_TARGETS} (for add_custom_command)
 add_executable(kanagawa::exe IMPORTED GLOBAL)
 set_target_properties(kanagawa::exe PROPERTIES
     IMPORTED_LOCATION "${KANAGAWA_EXE_DEST}"
 )
-
-# Make the imported exe depend on the build of the real exe (+ lib copy)
-add_dependencies(kanagawa::exe kanagawa_runtime)

--- a/test/syntax/CMakeLists.txt
+++ b/test/syntax/CMakeLists.txt
@@ -10,7 +10,7 @@
 # that the kanagawa compiler has been built.
 
 add_custom_target(syntax_tests
-    DEPENDS kanagawa::exe
+    DEPENDS kanagawa_runtime
 )
 
 # Add a target to run all syntax tests


### PR DESCRIPTION
This change solves the following issue:

1) Build a target which invokes the Kanagawa compiler to generate RTL (e.g., `ninja -v -j 1 library_test.data_memory_pipelined.kanagawa`)
2) Change a compiler source file (e.g., `Verilog.cpp`)
3) Rebuild the target - notice that the Kanagawa compiler is not rebuilt nor re-run

There are two issues, poorly documented in CMake, I learned about them by chatting with AIs.

1) CMake doesn't track dependencies through an imported executable (e.g., `add_executable(kanagawa::exe IMPORTED GLOBAL)`).  So making a target depend on kanagawa::exe effectively does nothing.

2) CMake doesn't find the transitive closure of dependencies specified via add_custom_command  (AI chat [here](https://claude.ai/share/544e71ff-cb36-4e31-8db7-1e05f393858e)).  This means that changing add_custom_command to depend on kanagawa_exe rather than kangawa::exe still does not solve the problem.  The fix is to make add_custom_command depend on real targets, not phony ones.