### PR TITLE
Enable syntax highlighting of Kanagawa

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.k linguist-language=C++


### PR DESCRIPTION
This enables syntax highlighting of Kanagawa source code as if it was C++ which covers majority of the grammar. Proper syntax support could be enabled after contributing Kanagawa grammar to Linguist.