### PR TITLE
Add build of sandcastle and risc-v-elf2mem

### DIFF
--- a/.github/workflows/build-compiler.yml
+++ b/.github/workflows/build-compiler.yml
@@ -225,6 +225,12 @@ jobs:
       - name: Build kanagawa_runtime
         run: cmake --build "${{ env.BUILD_DIR }}" --target kanagawa_runtime --parallel
 
+      - name: Build sandcastle
+        run: cmake --build "${{ env.BUILD_DIR }}" --target sandcastle_exe --parallel
+
+      - name: Build risc-v-elf2mem
+        run: cmake --build "${{ env.BUILD_DIR }}" --target risc-v-elf2mem --parallel
+
       - name: Log ccache stats
         shell: bash
         run: |


### PR DESCRIPTION
Add build of sandcastle and risc-v-elf2mem to CI build workflow.

closes #42 