### PR TITLE
Refactor github workflow; add compiler and sandcastle internal tests

### DIFF
--- a/.github/workflows/build-targets-template.yml
+++ b/.github/workflows/build-targets-template.yml
@@ -1,4 +1,4 @@
-name: Build Compiler Template (Reusable)
+name: Build and Test Targets Template
 
 on:
   workflow_call:
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       test-targets:
-        description: 'Space-separated list of CMake test targets to run (optional - will run after build-targets)'
+        description: 'Space-separated list of CMake test targets to build (optional - will run after build-targets)'
         required: false
         type: string
         default: ''
@@ -286,7 +286,7 @@ jobs:
             cmake --build "${{ env.BUILD_DIR }}" --target "$target" --parallel
           done
 
-      - name: Upload compiler binaries
+      - name: Upload artifacts
         if: ${{ inputs.artifact-name != '' }}
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -20,19 +20,19 @@ jobs:
       build-targets: 'kanagawa_runtime compiler_internal_test'
       test-targets: 'run_compiler_tests'
       artifact-name: 'kanagawa-linux-compiler-${{ github.sha }}'
-      artifact-path: 'build-ci/dist/bin/**'
+      artifact-path: 'build-ci/dist/**'
       cmake-build-type: 'RelWithDebInfo'
       runs-on: 'ubuntu-24.04'
       boost-platform-version: '24.04'
 
-  # Temporarily disabled until CMake supports macOS
+  # Temporarily disabled until the CMake configuration supports macOS
   # build-macos:
   #   uses: ./.github/workflows/build-targets-template.yml
   #   with:
   #     build-targets: 'kanagawa_runtime'
   #     test-targets: 'compiler_internal_test'
   #     artifact-name: 'kanagawa-macos-compiler-${{ github.sha }}'
-  #     artifact-path: 'build-ci/dist/bin/**'
+  #     artifact-path: 'build-ci/dist/**'
   #     cmake-build-type: 'RelWithDebInfo'
   #     runs-on: 'macos-14'
   #     boost-platform-version: '14'

--- a/.github/workflows/sandcastle-test.yml
+++ b/.github/workflows/sandcastle-test.yml
@@ -20,18 +20,18 @@ jobs:
       build-targets: 'sandcastle_exe'
       test-targets: 'run_sandcastle_tests'
       artifact-name: 'kanagawa-linux-sandcastle-${{ github.sha }}'
-      artifact-path: 'build-ci/dist/bin/**'
+      artifact-path: 'build-ci/dist/**'
       cmake-build-type: 'RelWithDebInfo'
       runs-on: 'ubuntu-24.04'
       boost-platform-version: '24.04'
 
-  # Temporarily disabled until CMake supports macOS
+  # Temporarily disabled until the CMake configuration supports macOS
   # build-macos:
   #   uses: ./.github/workflows/build-targets-template.yml
   #   with:
   #     build-targets: 'run_sandcastle_tests'
   #     artifact-name: 'kanagawa-macos-sandcastle-${{ github.sha }}'
-  #     artifact-path: 'build-ci/dist/bin/**'
+  #     artifact-path: 'build-ci/dist/**'
   #     cmake-build-type: 'RelWithDebInfo'
   #     runs-on: 'macos-14'
   #     boost-platform-version: '14'


### PR DESCRIPTION
- Refactor the Github workflow to make a template that can be used across multiple workflows and (eventually) target multiple OS.
- Update the existing workflow to build just the compiler and then run the compiler internal tests
- Add a workflow that builds sandcastle and runs the sandcastle internal tests

Closes #45 
Closes #46 
