### PR TITLE
Fix overactive warning about missing [[transaction_size(N)]] attribute

### DIFF
--- a/compiler/cpp/lower.cpp
+++ b/compiler/cpp/lower.cpp
@@ -5388,8 +5388,12 @@ void SetFifoTransactionSizes(Program& program)
 
                         const Function* const dstFunction = dstBlock->_function;
 
+                        const bool isFunctionCall = (op._flags._enqueue._type == EnqueueType::FunctionCall);
+
                         if (transactionSize > 0)
                         {
+                            assert(isFunctionCall);
+
                             // Determine which bit is the end_transaction bit
                             const size_t endTransactionLocalRegister = dstFunction->GetEndTransactionRegister();
 
@@ -5399,7 +5403,7 @@ void SetFifoTransactionSizes(Program& program)
                             regDesc.Fifo()._transactionBitOffset = transactionBitOffset;
                             regDesc.Fifo()._transactionSize = transactionSize;
                         }
-                        else if (enableTransactionSizeWarning && dstFunction->HasEndTransactionParameter())
+                        else if (enableTransactionSizeWarning && dstFunction->HasEndTransactionParameter() && isFunctionCall)
                         {
                             Location loc = {};
 

--- a/test/logic/last.k
+++ b/test/logic/last.k
@@ -299,6 +299,8 @@ inline void TestIndirectTransaction(unit::tag_t tag)
     class Helper
     {
     private:
+        const auto MaxTransactionSize = TransactionSizeA > TransactionSizeB ? TransactionSizeA : TransactionSizeB;
+
         uint32 Shared([[last]] bool is_last)
         {
             return first(atomically([](uint32 prev)->uint32{return prev + 1;}));
@@ -308,7 +310,7 @@ inline void TestIndirectTransaction(unit::tag_t tag)
         // But calls Shared which has multiple call sites
         uint32 SingleCallSite([[last]] bool is_last)
         {
-            return Shared(is_last);
+            return [[transaction_size(MaxTransactionSize)]] Shared(is_last);
         }
 
         inline void ValidateResult(unit::tag_t tag, uint32 tid, uint32 transaction_size, uint32 actual)


### PR DESCRIPTION
Fix a bug in the compiler which would cause it to incorrectly emit the warning:

```
Call to function with [[last]] parameter without [[transaction_size]] at the call site
```

The fix is to only issue this warning for `Opcode::Enqueue` operations which enqueue function parameters, and not others (e.g., returning from a function).

Also, eliminate one instance for this warning from a test in `last.k`.