### PR TITLE
Fix parsing of module names

### DIFF
--- a/compiler/hs/lib/Language/Kanagawa/Parser.hs
+++ b/compiler/hs/lib/Language/Kanagawa/Parser.hs
@@ -179,7 +179,7 @@ program parseFile = (moduleDecl <|> declarations) >>= checkExposed >>= checkRedu
     moduleName = choice
         [ pure <$> L.symbol cmdargsSpecialModule
         , pure <$> L.symbol optionsSpecialModule
-        , name' `MP.sepBy1` dot
+        , dotSepName
         ] <?> "module name"
 
     moduleDecl = do

--- a/compiler/hs/lib/Language/Kanagawa/Parser/Lexer.hs
+++ b/compiler/hs/lib/Language/Kanagawa/Parser/Lexer.hs
@@ -11,7 +11,7 @@ module Language.Kanagawa.Parser.Lexer
     ( symbol
     , lexeme
     , name
-    , name'
+    , dotSepName
     , stringLiteral
     , integer
     , L.decimal
@@ -227,8 +227,8 @@ ident' f = (:) <$> (letterChar <|> char '_') <*> takeWhileP (Just "rest of ident
 ident :: MonadParsec e String m => m String
 ident = ident' isAlphaNumOrUnderscore
 
-name' :: (MonadParsec e String m, MonadReader Config m) => m String
-name' = lexeme $ try $ ident' isAlphaNumOrDashOrUnderscore
+dotSepName :: (MonadParsec e String m, MonadReader Config m) => m [String]
+dotSepName = lexeme $ try (ident' isAlphaNumOrDashOrUnderscore `sepBy1` char '.')
   where
     isAlphaNumOrDashOrUnderscore c = isAlphaNumOrUnderscore c || c == '-'
 

--- a/test/syntax/imports.k
+++ b/test/syntax/imports.k
@@ -17,7 +17,7 @@ expected:1
 expected:1
 
     import a1.a1
-    
+
     inline void main()
     {
         static a1<10> a;
@@ -26,7 +26,7 @@ expected:1
 expected:0
 
     import a1.a1
-    
+
     inline void main()
     {
         static b1<10> b;
@@ -36,7 +36,7 @@ expected:1
 
     import a1.a1
     import a1.b1.b1
-    
+
     inline void main()
     {
         static a1<10> a;
@@ -46,7 +46,7 @@ expected:1
 expected:0
 
     import a1.b1.b1
-    
+
     inline void main()
     {
         static b1<10> b;
@@ -55,7 +55,7 @@ expected:0
 expected:0
 
     import a1.b1.c1.c1
-    
+
     inline void main()
     {
         static c1<10> c;
@@ -64,7 +64,7 @@ expected:0
 expected:0
 
     import a1.b2.c1.c1
-    
+
     inline void main()
     {
         static c1<10> c;
@@ -77,7 +77,7 @@ expected:0
     {
         uint32 x;
     }
-    
+
     inline void main()
     {
         static c1 c;
@@ -143,7 +143,7 @@ expected:0
 expected:0
 
     import a1.b2.b2
-    
+
     inline void main()
     {
         static c1<10> c;
@@ -153,7 +153,7 @@ expected:1
 
     import a1.b1.c1.c1
     import a1.b2.c1.c1
-    
+
     inline void main()
     {
         static c1<10> c;
@@ -163,7 +163,7 @@ expected:1
 
     import a1.b1.b1
     import a1.b2.b2
-    
+
     inline void main()
     {
         static b1<10> b;
@@ -173,7 +173,7 @@ expected:0
 
     import a1.b1.b1
     import a1.b2.b2
-    
+
     inline void main()
     {
         static b2<10> b;
@@ -183,7 +183,7 @@ expected:0
 
     import a1.b1.b1
     import a1.b2.b2
-    
+
     inline void main()
     {
         static b1<10> b;
@@ -891,7 +891,7 @@ warning:0
     import diff.foo_minus_bar
 
     static assert(foo == 3);
-    
+
     inline void main()
     {
         static foo_t x;
@@ -1058,3 +1058,15 @@ expected:0
     static assert(x == 11);
 
 expected:0
+
+    import a1 .a1
+
+expected:1
+
+    import a1. a1
+
+expected:1
+
+    import a1 . a1
+
+expected:1


### PR DESCRIPTION
Disallow white spaces within module names, for example:

    import data .array

is not valid and should cause compiler error.