### PR TITLE
Improve type of RISC-V decode_format function

### DIFF
--- a/library/processor/risc_v/isa.k
+++ b/library/processor/risc_v/isa.k
@@ -378,7 +378,7 @@ enum Format : uint3
 
 //| Decode instruction word in given instruction format
 template <Base ISA>
-inline auto decode_format
+inline Types<ISA>::Decoded decode_format
     ( Instr instr   //< Instruction word
     , Format format //< Instruction format
     )


### PR DESCRIPTION
Declare explicit return type of the `decode_format` function instead of `auto` so that generated documentation shows the return type with a link to its description.