### PR TITLE
Add formatting to Sandcastle generated index.html

### DIFF
--- a/tools/sandcastle/lib/Sandcastle.hs
+++ b/tools/sandcastle/lib/Sandcastle.hs
@@ -68,8 +68,7 @@ app =
 
     -- Write module index file
     sort moduleList
-      & moduleForest ext
-      & (header 1 "Modules" <>)
+      & moduleForest ext fmt
       & doc
       & writePandoc fmt
       & UTF8.writeFile (output cli </> "index" <.> ext)

--- a/tools/sandcastle/lib/Sandcastle/Css.hs
+++ b/tools/sandcastle/lib/Sandcastle/Css.hs
@@ -112,7 +112,8 @@ docsDetailsStyle = ".docs details" ? do
   marginTop         (em 1)
 
 headersStyle :: Css
-headersStyle = ".body h1, h2, h3, h4" ? do
+headersStyle = "h1, h2, h3, h4" ? do
+  fontFamily        [""] [sansSerif]
   color             hokusaiDarkBlue
 
 kanagawaStyle :: Css

--- a/tools/sandcastle/lib/Sandcastle/DocGen.hs
+++ b/tools/sandcastle/lib/Sandcastle/DocGen.hs
@@ -779,9 +779,14 @@ classMembers bdy = catMaybes $ flip mapClassMembers bdy $ curry $ \case
 -- Module forest --
 -------------------
 
-moduleForest :: String -> [[String]] -> Blocks
-moduleForest ext =
-  blockHtml . withPre . drawPowerline . (fmap.fmap) T.pack . mkModuleForest ext
+moduleForest :: String -> Cli.Format -> [[String]] -> Blocks
+moduleForest ext fmt ms = case fmt of
+    Html     -> styleBlocks htmlStyle <> nav (hdr <> mods)
+    Markdown -> hdr <> mods
+  where
+    nav  = divWith ("nav", ["nav"], [])
+    hdr  = header 1 "Modules"
+    mods = blockHtml $ withPre $ drawPowerline $ (fmap.fmap) T.pack $ mkModuleForest ext ms
 
 mkModuleForest :: String -> [[String]] -> [Tree String]
 mkModuleForest ext = go [] . groupByHead


### PR DESCRIPTION
Add CSS styling to the generated index.html page to make formatting consistent with module documentation pages.