### PR TITLE
Remove --Wno-transaction-size for is_last_exported_class test

### DIFF
--- a/test/interface/CMakeLists.txt
+++ b/test/interface/CMakeLists.txt
@@ -126,8 +126,6 @@ add_interface_test(is_last_exported_class is_last_exported_class.k
     IsLastExportedClass_types.sv
   TESTBENCH
     is_last_exported_class.sv
-  OPTIONS
-    "--Wno-transaction-size" # Warning 10  Call to function with [[last]] parameter without [[transaction_size]] at the call site
 )
 
 add_interface_test(external_class external_class.k

--- a/test/interface/is_last_exported_class.k
+++ b/test/interface/is_last_exported_class.k
@@ -19,7 +19,7 @@ public:
             {
                 pipelined_for(16, [](index_t<16> i)
                 {
-                    cb(i, i==15);
+                    [[transaction_size(16)]] cb(i, i==15);
                 });
             });
         }


### PR DESCRIPTION
Fixup the `is_last_exported_class` interface test so that it can compiler without `--Wno-transaction-size`.