### PR TITLE
Fix generated documentation of extern classes

### DIFF
--- a/tools/sandcastle/lib/Sandcastle/DocGen.hs
+++ b/tools/sandcastle/lib/Sandcastle/DocGen.hs
@@ -297,6 +297,7 @@ memberGroup = \case
   Class{}         -> Types
   Enum{}          -> Types
   Function{}      -> Functions
+  FunctionDecl{}  -> Functions
   StaticAssert{}  -> Invariants
   Struct{}        -> Types
   Template _ decl -> memberGroup decl
@@ -397,8 +398,7 @@ rFunctionDecl
   -> (Doc SigAnn, Blocks)
 rFunctionDecl attrs rt ident fps anc desc =
   ( cat $ withAttrList attrs
-      [ annotate Keyword "extern"
-      , cat $ sig rt <> flatAlt "" " " :
+      [ cat $ sig rt <> flatAlt "" " " :
           [ nest 4 $ cat $ (<> [")" <+> anc]) $
               sig ident <> "(" : punctuate (flatAlt "," ", ") (sig <$> fps)
           ]


### PR DESCRIPTION
This commit fixes two issues with Sandcastle generated documentation for method declarations in extern classes:
- List the method declarations under "Methods" rather than "General"
- Remove spurious `extern` keyword in the method signature.

For example of these problems see documentation of `compiler.hal` library module.