### PR TITLE
Add missing dependency install (svgbob_cli) to Publish Library Documentation workflow

### DIFF
--- a/.github/workflows/publish-libdoc.yml
+++ b/.github/workflows/publish-libdoc.yml
@@ -22,6 +22,7 @@ jobs:
       cmake-build-type: 'RelWithDebInfo'
       runs-on: 'ubuntu-24.04'
       boost-platform-version: '24.04'
+      install-svgbob: true
 
   publish-to-github-pages:
     needs: build-and-publish


### PR DESCRIPTION
Add missing dependency install (svgbob_cli) that broke the 'Publish Library Documentation' workflow