### PR TITLE
Update Verilator to version 5.040

### DIFF
--- a/.github/workflows/build-targets-template.yml
+++ b/.github/workflows/build-targets-template.yml
@@ -195,7 +195,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: veryl-lang/setup-verilator@v1
         with:
-          version: '5.036'
+          version: '5.040'
 
       - name: Install Boost
         id: install_boost

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -151,7 +151,7 @@ each item in the list.
 - Boost C++ library version 1.88.0 or later (see https://www.boost.org/)
 - CMake version 3.30 or later (see https://cmake.org/)
 - Ninja. It's not required to use Ninja; you can use any build tool supported by CMake, but we recommend Ninja for its speed and simplicity (see https://ninja-build.org/)
-- Verilator version 5.036. See the [Verilator documentation](https://veripool.org/guide/latest/install.html#git-quick-install) for detailed instructions. Note that version 5.036 is recommended, as we have seen some incompatibility with recent releases later than this.
+- Verilator version 5.040. See the [Verilator documentation](https://veripool.org/guide/latest/install.html#git-quick-install) for detailed instructions.
 - Python version 3.x
 
 To run the tests for the Kanagawa RISC-V processor implementation, you will need to install:


### PR DESCRIPTION
This PR updates the Verilator version requirement from 5.036 to 5.040 across documentation and CI workflow configuration, aligning with the latest version supported by the veryl-lang/setup-verilator action.

**Key Changes:**
- Updated Verilator version from 5.036 to 5.040 in both documentation and CI configuration
- Removed the compatibility warning note that recommended sticking with version 5.036