### PR TITLE
[Docker] Revert to Ubuntu 22.04

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@
 #   - A VS Code / GitHub Codespaces devcontainer (via devcontainer.json)
 #   - A GitHub Copilot coding agent build environment
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
For those of us who use the Dockerfile for internal builds, support Ubuntu 22.04.