### PR TITLE
Apply identifier-length to basic block module and container instance names (fix for #122)

### DIFF
--- a/compiler/cpp/circt_util.cpp
+++ b/compiler/cpp/circt_util.cpp
@@ -592,7 +592,7 @@ mlir::StringAttr GetFullyQualifiedStringAttr(const ObjectPath &containerPath, co
     ObjectPath pathWithField = containerPath;
     pathWithField.push_back("__field__" + fieldName);
 
-    return StringToStringAttr(FixupStringCirct(SerializePath(pathWithField, '_')));
+    return ClampedSymAttr(FixupStringCirct(SerializePath(pathWithField, '_')));
 }
 
 circt::hw::InnerSymAttr GetFullyQualifiedInnerSymAttr(const ObjectPath &containerPath, const std::string &fieldName)

--- a/compiler/cpp/circt_util.cpp
+++ b/compiler/cpp/circt_util.cpp
@@ -366,7 +366,7 @@ mlir::Value GetPathOp(circt::OpBuilder &opb, const ObjectPath &srcPath, const Ob
 
     while (currPath != commonRoot)
     {
-        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(StringToStringAttr(currPath.back()));
+        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(ClampedSymAttr(currPath.back()));
 
         const mlir::Attribute step = circt::kanagawa::PathStepAttr::get(
             g_compiler->GetMlirContext(), circt::kanagawa::PathDirection::Parent,
@@ -384,7 +384,7 @@ mlir::Value GetPathOp(circt::OpBuilder &opb, const ObjectPath &srcPath, const Ob
 
         const std::string stepName = dstPath[currPath.size()];
 
-        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(StringToStringAttr(stepName));
+        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(ClampedSymAttr(stepName));
 
         const mlir::Attribute step = circt::kanagawa::PathStepAttr::get(
             g_compiler->GetMlirContext(), circt::kanagawa::PathDirection::Child,
@@ -592,7 +592,7 @@ mlir::StringAttr GetFullyQualifiedStringAttr(const ObjectPath &containerPath, co
     ObjectPath pathWithField = containerPath;
     pathWithField.push_back("__field__" + fieldName);
 
-    return StringToStringAttr(g_compiler->ClampStringLength(FixupStringCirct(SerializePath(pathWithField, '_'))));
+    return StringToStringAttr(FixupStringCirct(SerializePath(pathWithField, '_')));
 }
 
 circt::hw::InnerSymAttr GetFullyQualifiedInnerSymAttr(const ObjectPath &containerPath, const std::string &fieldName)
@@ -2185,7 +2185,7 @@ mlir::Value ModuleDeclarationHelper::GetPort(circt::OpBuilder &opb, const Object
 
     while (currPath != commonRoot)
     {
-        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(StringToStringAttr(currPath.back()));
+        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(ClampedSymAttr(currPath.back()));
 
         const mlir::Attribute step = circt::kanagawa::PathStepAttr::get(
             g_compiler->GetMlirContext(), circt::kanagawa::PathDirection::Parent,
@@ -2203,7 +2203,7 @@ mlir::Value ModuleDeclarationHelper::GetPort(circt::OpBuilder &opb, const Object
 
         const std::string stepName = dstPath[currPath.size()];
 
-        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(StringToStringAttr(stepName));
+        const mlir::FlatSymbolRefAttr symbolRef = mlir::FlatSymbolRefAttr::get(ClampedSymAttr(stepName));
 
         const mlir::Attribute step = circt::kanagawa::PathStepAttr::get(
             g_compiler->GetMlirContext(), circt::kanagawa::PathDirection::Child,

--- a/compiler/cpp/circt_util.cpp
+++ b/compiler/cpp/circt_util.cpp
@@ -592,7 +592,7 @@ mlir::StringAttr GetFullyQualifiedStringAttr(const ObjectPath &containerPath, co
     ObjectPath pathWithField = containerPath;
     pathWithField.push_back("__field__" + fieldName);
 
-    return StringToStringAttr(FixupStringCirct(SerializePath(pathWithField, '_')));
+    return StringToStringAttr(g_compiler->ClampStringLength(FixupStringCirct(SerializePath(pathWithField, '_'))));
 }
 
 circt::hw::InnerSymAttr GetFullyQualifiedInnerSymAttr(const ObjectPath &containerPath, const std::string &fieldName)

--- a/compiler/cpp/circt_util.cpp
+++ b/compiler/cpp/circt_util.cpp
@@ -439,6 +439,11 @@ mlir::StringAttr StringToStringAttr(const std::string &str)
     return mlir::StringAttr::get(g_compiler->GetMlirContext(), str);
 }
 
+mlir::StringAttr ClampedSymAttr(const std::string &str)
+{
+    return StringToStringAttr(g_compiler->ClampStringLength(str));
+}
+
 mlir::IntegerType GetIntegerType(const size_t width, mlir::IntegerType::SignednessSemantics signedness)
 {
     return mlir::IntegerType::get(g_compiler->GetMlirContext(), width, signedness);

--- a/compiler/cpp/circt_util.h
+++ b/compiler/cpp/circt_util.h
@@ -69,6 +69,8 @@ mlir::Value LiteralToValue(const Literal& l, circt::OpBuilder& opb, const mlir::
 
 mlir::StringAttr StringToStringAttr(const std::string& str);
 
+mlir::StringAttr ClampedSymAttr(const std::string& str);
+
 size_t GetMlirTypeWidth(const mlir::Type& type);
 
 size_t GetMlirValueWidth(const mlir::Value& v);

--- a/compiler/cpp/compiler.cpp
+++ b/compiler/cpp/compiler.cpp
@@ -1902,6 +1902,33 @@ std::string Compiler::ClampStringLength(const std::string& stringIn)
 
     if (result.size() > limit)
     {
+        // If input already clamped, return a no-op. Avoids generating different strings for the same input on different passes
+        if (const size_t underscore = stringIn.rfind('_'); underscore != std::string::npos)
+        {
+            const std::string suffix = stringIn.substr(underscore + 1);
+            if (!suffix.empty() && std::all_of(suffix.begin(), suffix.end(), [](char c) { return std::isdigit(static_cast<unsigned char>(c)); }))
+            {
+                try
+                {
+                    const size_t parsedHash = std::stoull(suffix);
+                    const auto existing = _clampStringMap.find(parsedHash);
+                    if (existing != _clampStringMap.end())
+                    {
+                        std::ostringstream expected;
+                        expected << existing->second.substr(0, limit) << "_" << parsedHash;
+                        if (expected.str() == stringIn)
+                        {
+                            return stringIn;
+                        }
+                    }
+                }
+                catch (const std::exception&)
+                {
+                    // not a hash suffix; fall through
+                }
+            }
+        }
+        
         // Compute a hash code of the full string
         std::hash<std::string> hasher;
 

--- a/compiler/cpp/compiler.cpp
+++ b/compiler/cpp/compiler.cpp
@@ -1902,33 +1902,6 @@ std::string Compiler::ClampStringLength(const std::string& stringIn)
 
     if (result.size() > limit)
     {
-        // If input already clamped, return a no-op. Avoids generating different strings for the same input on different passes
-        if (const size_t underscore = stringIn.rfind('_'); underscore != std::string::npos)
-        {
-            const std::string suffix = stringIn.substr(underscore + 1);
-            if (!suffix.empty() && std::all_of(suffix.begin(), suffix.end(), [](char c) { return std::isdigit(static_cast<unsigned char>(c)); }))
-            {
-                try
-                {
-                    const size_t parsedHash = std::stoull(suffix);
-                    const auto existing = _clampStringMap.find(parsedHash);
-                    if (existing != _clampStringMap.end())
-                    {
-                        std::ostringstream expected;
-                        expected << existing->second.substr(0, limit) << "_" << parsedHash;
-                        if (expected.str() == stringIn)
-                        {
-                            return stringIn;
-                        }
-                    }
-                }
-                catch (const std::exception&)
-                {
-                    // not a hash suffix; fall through
-                }
-            }
-        }
-        
         // Compute a hash code of the full string
         std::hash<std::string> hasher;
 

--- a/compiler/cpp/verilog.cpp
+++ b/compiler/cpp/verilog.cpp
@@ -12095,7 +12095,7 @@ private:
 
     std::string GenericContainerName(const ObjectPath &path)
     {
-        return path.empty() ? _coreModule->Name() : g_compiler->ClampStringLength(FixupString(SerializePath(path)));
+        return path.empty() ? _coreModule->Name() : FixupString(SerializePath(path));
     }
 };
 

--- a/compiler/cpp/verilog.cpp
+++ b/compiler/cpp/verilog.cpp
@@ -495,8 +495,8 @@ std::string GetRegisterBaseName(const Program &program, const size_t registerInd
     return prefix + std::to_string(registerIndex) + "_" + regDesc._name;
 }
 
-std::string GetBasicBlockInstanceName(const BasicBlock &basicBlock) { 
-    return g_compiler->ClampStringLength(GetBasicBlockName(basicBlock) + "Impl"); 
+std::string GetBasicBlockInstanceName(const BasicBlock &basicBlock) {
+    return g_compiler->ClampStringLength(GetBasicBlockName(basicBlock) + "Impl");
 }
 
 class VerilogCompiler;
@@ -1643,7 +1643,7 @@ public:
                 const mlir::Location location = RegDescToLocation(regDesc);
 
                 circt::kanagawa::ContainerInstanceOp::create(opb,
-                                                             location, 
+                                                             location,
                                                              circt::hw::InnerSymAttr::get(ClampedSymAttr(containerInstancePath.back())),
                                                              circt::hw::InnerRefAttr::get(StringToStringAttr(GetCirctDesignName()), leafContainerNameAttr));
 
@@ -2813,7 +2813,7 @@ public:
                     opb.setInsertionPointToEnd(parentContainer.getBodyBlock());
 
                     circt::kanagawa::ContainerInstanceOp::create(opb,
-                                                                 location, 
+                                                                 location,
                                                                  circt::hw::InnerSymAttr::get(ClampedSymAttr(containerInstancePath.back())),
                                                                  circt::hw::InnerRefAttr::get(StringToStringAttr(GetCirctDesignName()), leafContainerNameAttr));
 
@@ -5537,7 +5537,7 @@ public:
 
         str << "global_out_" << regDesc._name << "_" << registerIndex << "_" << writeIndex;
 
-        return str.str();
+        return g_compiler->ClampStringLength(str.str());
     }
 
     std::string GetGlobalValidOutName(const size_t registerIndex, const size_t writeIndex) const
@@ -5546,7 +5546,7 @@ public:
 
         result += "_valid";
 
-        return result;
+        return g_compiler->ClampStringLength(result);
     }
 
     std::string GetGlobalInName(const size_t registerIndex) const
@@ -5559,7 +5559,7 @@ public:
 
         str << "global_in_" << regDesc._name << "_" << registerIndex;
 
-        return str.str();
+        return g_compiler->ClampStringLength(str.str());
     }
 
     std::string GetGlobalInNextName(const size_t registerIndex) const
@@ -5572,7 +5572,7 @@ public:
 
         str << "global_in_" << regDesc._name << "_" << registerIndex << "_next";
 
-        return str.str();
+        return g_compiler->ClampStringLength(str.str());
     }
 
     // Returns the name of the variable that holds a global view value
@@ -12411,7 +12411,8 @@ void ModuleInstanceHelper::Generate(circt::OpBuilder *const opbIn)
                     // Use a name hint to ensure the wire generated from this verbatim op
                     // doesn't conflict with a name of a variable declared in another verbatim op
                     verbatimOp->setAttr("sv.namehint",
-                                        StringToStringAttr(_instanceName + "_" + port.name.str() + "__circt"));
+                                        StringToStringAttr(g_compiler->ClampStringLength(
+                                            _instanceName + "_" + port.name.str() + "__circt")));
 
                     const mlir::Value input =
                         isClockType ? circt::seq::ToClockOp::create(opb, _location, GetClockType(),

--- a/compiler/cpp/verilog.cpp
+++ b/compiler/cpp/verilog.cpp
@@ -496,7 +496,7 @@ std::string GetRegisterBaseName(const Program &program, const size_t registerInd
 }
 
 std::string GetBasicBlockInstanceName(const BasicBlock &basicBlock) { 
-    return g_compiler->ClampStringLength((basicBlock) + "Impl"); 
+    return g_compiler->ClampStringLength(GetBasicBlockName(basicBlock) + "Impl"); 
 }
 
 class VerilogCompiler;
@@ -8232,7 +8232,7 @@ private:
                     mlir::Value inputSliceWire = circt::sv::LogicOp::create(opb,
                                                                             mlirBbLocation, sliceType, StringToStringAttr(inputWireName),
                                                                             GetFullyQualifiedInnerSymAttr(basicBlock.GetObjectPath(), inputWireName));
-                                                                            
+
                     SafeInsert(offsetToInputWire, sliceOffset, inputSliceWire);
 
                     sparseConcat.Insert(sliceOffset,
@@ -12095,7 +12095,7 @@ private:
 
     std::string GenericContainerName(const ObjectPath &path)
     {
-        return path.empty() ? _coreModule->Name() : g_compiler->ClampStringLength((SerializePath(path)));
+        return path.empty() ? _coreModule->Name() : g_compiler->ClampStringLength(FixupString(SerializePath(path)));
     }
 };
 

--- a/compiler/cpp/verilog.cpp
+++ b/compiler/cpp/verilog.cpp
@@ -495,7 +495,9 @@ std::string GetRegisterBaseName(const Program &program, const size_t registerInd
     return prefix + std::to_string(registerIndex) + "_" + regDesc._name;
 }
 
-std::string GetBasicBlockInstanceName(const BasicBlock &basicBlock) { return GetBasicBlockName(basicBlock) + "Impl"; }
+std::string GetBasicBlockInstanceName(const BasicBlock &basicBlock) { 
+    return g_compiler->ClampStringLength((basicBlock) + "Impl"); 
+}
 
 class VerilogCompiler;
 
@@ -1641,7 +1643,8 @@ public:
                 const mlir::Location location = RegDescToLocation(regDesc);
 
                 circt::kanagawa::ContainerInstanceOp::create(opb,
-                                                             location, circt::hw::InnerSymAttr::get(StringToStringAttr(containerInstancePath.back())),
+                                                             location, 
+                                                             circt::hw::InnerSymAttr::get(ClampedSymAttr(containerInstancePath.back())),
                                                              circt::hw::InnerRefAttr::get(StringToStringAttr(GetCirctDesignName()), leafContainerNameAttr));
 
                 // Write clock and reset ports
@@ -2810,7 +2813,8 @@ public:
                     opb.setInsertionPointToEnd(parentContainer.getBodyBlock());
 
                     circt::kanagawa::ContainerInstanceOp::create(opb,
-                                                                 location, circt::hw::InnerSymAttr::get(StringToStringAttr(containerInstancePath.back())),
+                                                                 location, 
+                                                                 circt::hw::InnerSymAttr::get(ClampedSymAttr(containerInstancePath.back())),
                                                                  circt::hw::InnerRefAttr::get(StringToStringAttr(GetCirctDesignName()), leafContainerNameAttr));
 
                     // Write clock and reset ports
@@ -5621,7 +5625,7 @@ public:
 
                     ModuleInstanceHelper instance(*this, LocationToCirctLocation(basicBlock._location));
 
-                    instance.SetModuleName(GetModuleNamePrefix() + GetBasicBlockName(basicBlock));
+                    instance.SetModuleName(g_compiler->ClampStringLength(GetModuleNamePrefix() + GetBasicBlockName(basicBlock)));
                     instance.SetInstanceName(GetBasicBlockInstanceName(basicBlock));
 
                     instance.AddPort("clk", circt::hw::ModulePort::Direction::Input, GetClockType(), "clk");
@@ -7635,7 +7639,7 @@ private:
         const std::set<size_t> acquiredSemaphores = GetAcquiredSemaphores(basicBlock);
         const std::set<size_t> releasedSemaphores = GetReleasedSemaphores(basicBlock);
 
-        const std::string fullModuleName = GetModuleNamePrefix() + GetBasicBlockName(basicBlock);
+        const std::string fullModuleName = g_compiler->ClampStringLength(GetModuleNamePrefix() + GetBasicBlockName(basicBlock));
 
         JsonValue jsonBasicBlock = JsonValue::CreateObject();
         JsonValue jsonPorts = JsonValue::CreateArray();
@@ -8228,7 +8232,7 @@ private:
                     mlir::Value inputSliceWire = circt::sv::LogicOp::create(opb,
                                                                             mlirBbLocation, sliceType, StringToStringAttr(inputWireName),
                                                                             GetFullyQualifiedInnerSymAttr(basicBlock.GetObjectPath(), inputWireName));
-
+                                                                            
                     SafeInsert(offsetToInputWire, sliceOffset, inputSliceWire);
 
                     sparseConcat.Insert(sliceOffset,
@@ -11426,7 +11430,7 @@ private:
             basicBlockPorts.push_back(pi._portInfo);
         }
 
-        const std::string moduleName = GetModuleNamePrefix() + GetBasicBlockName(basicBlock);
+        const std::string moduleName = g_compiler->ClampStringLength(GetModuleNamePrefix() + GetBasicBlockName(basicBlock));
 
         _compileContext._hwModule =
             circt::hw::HWModuleOp::create(opb, mlirBbLocation, opb.getStringAttr(moduleName), basicBlockPorts);
@@ -11999,7 +12003,8 @@ private:
             opb.setInsertionPointToEnd(parentContainer.getBodyBlock());
 
             circt::kanagawa::ContainerInstanceOp instance = circt::kanagawa::ContainerInstanceOp::create(opb,
-                                                                                                         GetUnknownLocation(), circt::hw::InnerSymAttr::get(StringToStringAttr(path.back())),
+                                                                                                         GetUnknownLocation(),
+                                                                                                         circt::hw::InnerSymAttr::get(ClampedSymAttr(path.back())),
                                                                                                          circt::hw::InnerRefAttr::get(StringToStringAttr(GetCirctDesignName()), containerNameAttr));
 
             SafeInsert(_pathToContainerInstance, path, ContainerAndInstance(container, instance));
@@ -12090,7 +12095,7 @@ private:
 
     std::string GenericContainerName(const ObjectPath &path)
     {
-        return path.empty() ? _coreModule->Name() : FixupString(SerializePath(path));
+        return path.empty() ? _coreModule->Name() : g_compiler->ClampStringLength((SerializePath(path)));
     }
 };
 


### PR DESCRIPTION
--identifier-length was not being applied to all generated instance names, resulting in generated code that could violate downstream tool (e.g. Quartus) name length limit checks. This PR applies the identifier-length also to basic-block module names and container instance names,