### PR TITLE
Bump CIRCT submodule and adapt to API changes

### DIFF
--- a/compiler/cpp/circt_util.cpp
+++ b/compiler/cpp/circt_util.cpp
@@ -664,7 +664,7 @@ void ConvertOpToCirct(const Operation &op, circt::OpBuilder &opb, const Program 
         const size_t srcWidth = op._src[0].Width(program);
 
         mlir::Value srcValue = srcToValue(op, 0, op._dst[0].Width(program));
-        mlir::Value v = circt::comb::createOrFoldNot(opLocation, srcValue, opb, TwoState);
+        mlir::Value v = circt::comb::createOrFoldNot(opb, opLocation, srcValue, TwoState);
 
         storeDst(op, 0, v);
     }
@@ -954,7 +954,7 @@ mlir::Value AdjustValueWidth(const mlir::Value &srcValue, const size_t desiredWi
         {
             assert(srcValueWidth > 0);
 
-            result = circt::comb::createOrFoldSExt(location, srcValue, opb.getIntegerType(desiredWidth), opb);
+            result = circt::comb::createOrFoldSExt(opb, location, srcValue, opb.getIntegerType(desiredWidth));
         }
         else
         {
@@ -2554,12 +2554,12 @@ std::string MlirModule::Generate()
     circt::LowerSeqToSVOptions lowerSeqToSVOptions = {};
     lowerSeqToSVOptions.lowerToAlwaysFF = !GetCodeGenDeviceConfig()._requirePowerOnReset;
     pm.addPass(circt::createLowerSeqToSVPass(lowerSeqToSVOptions));
-    pm.nest<circt::hw::HWModuleOp>().addPass(circt::sv::createHWCleanupPass()); // this merges always blocks
+    pm.nest<circt::hw::HWModuleOp>().addPass(circt::sv::createHWCleanup()); // this merges always blocks
     pm.addPass(mlir::createCSEPass());
     pm.addPass(circt::createSimpleCanonicalizerPass());
     pm.nest<circt::hw::HWModuleOp>().addPass(circt::createLowerHWToSVPass());
-    pm.nest<circt::hw::HWModuleOp>().addPass(circt::sv::createHWLegalizeModulesPass());
-    pm.nest<circt::hw::HWModuleOp>().addPass(circt::sv::createPrettifyVerilogPass());
+    pm.nest<circt::hw::HWModuleOp>().addPass(circt::sv::createHWLegalizeModules());
+    pm.nest<circt::hw::HWModuleOp>().addPass(circt::sv::createPrettifyVerilog());
 
     std::string generatedModule;
     llvm::raw_string_ostream generatedModuleStr(generatedModule);

--- a/compiler/cpp/verilog.cpp
+++ b/compiler/cpp/verilog.cpp
@@ -8312,7 +8312,7 @@ private:
         const std::string instNameIndex = instName + "_" + std::to_string(fifoIndex);
 
         const mlir::Value invFifoStatus =
-            circt::comb::createOrFoldNot(bbLocation, _compileContext.PortNameToValue(portNameIndex), opb, TwoState);
+            circt::comb::createOrFoldNot(opb, bbLocation, _compileContext.PortNameToValue(portNameIndex), TwoState);
 
         mlir::Value invFifoStatusSelected;
 
@@ -8450,8 +8450,8 @@ private:
                 std::ostringstream str;
 
                 mlir::Value notSemaphoreFull = circt::comb::createOrFoldNot(
-                    bbLocation,
-                    _compileContext.PortNameToValue("semaphore_full_" + std::to_string(semaphoreIndex) + "_in"), opb,
+                    opb, bbLocation,
+                    _compileContext.PortNameToValue("semaphore_full_" + std::to_string(semaphoreIndex) + "_in"),
                     TwoState);
 
                 allowThreadPredicates.push_back(notSemaphoreFull);
@@ -8571,7 +8571,7 @@ private:
 
                 // Don't trust fifo control signals during the reset sequence
                 allowThreadTerms.push_back(
-                    circt::comb::createOrFoldNot(bbLocation, _compileContext.PortNameToValue("rst"), opb, TwoState));
+                    circt::comb::createOrFoldNot(opb, bbLocation, _compileContext.PortNameToValue("rst"), TwoState));
 
                 if (!checkControlFifo0Only)
                 {
@@ -8650,7 +8650,7 @@ private:
                         std::ostringstream str;
 
                         writeConditions.push_back(circt::comb::createOrFoldNot(
-                            bbLocation, _compileContext.PortNameToValue("input_fifo_empty_" + std::to_string(i)), opb,
+                            opb, bbLocation, _compileContext.PortNameToValue("input_fifo_empty_" + std::to_string(i)),
                             TwoState));
 
                         if ((i == 0) && checkControlFifo0Only)
@@ -8762,7 +8762,7 @@ private:
                     mlir::SmallVector<mlir::Value> initialCallMadeThisCycleInputs;
 
                     initialCallMadeThisCycleInputs.push_back(
-                        circt::comb::createOrFoldNot(bbLocation, initialCallMadeRegBackedge, opb, TwoState));
+                        circt::comb::createOrFoldNot(opb, bbLocation, initialCallMadeRegBackedge, TwoState));
                     initialCallMadeThisCycleInputs.push_back(allowNewThread);
                     initialCallMadeThisCycleInputs.push_back(_compileContext.PortNameToValue("allow_initial_call_in"));
 
@@ -8788,7 +8788,7 @@ private:
                     if (basicBlock._inputFifoCount > 0)
                     {
                         const mlir::Value inputFifoNotEmpty = circt::comb::createOrFoldNot(
-                            bbLocation, _compileContext.PortNameToValue("input_fifo_empty_0"), opb, TwoState);
+                            opb, bbLocation, _compileContext.PortNameToValue("input_fifo_empty_0"), TwoState);
 
                         const mlir::Value fifoNotEmptyAllowNewThread =
                             circt::comb::AndOp::create(opb, bbLocation, inputFifoNotEmpty, allowNewThread, TwoState);
@@ -8797,7 +8797,7 @@ private:
                                                                                   bbLocation, fifoNotEmptyAllowNewThread, initialCallMadeThisCycle, TwoState);
 
                         const mlir::Value initCallNotThisCycle =
-                            circt::comb::createOrFoldNot(bbLocation, initialCallMadeThisCycle, opb, TwoState);
+                            circt::comb::createOrFoldNot(opb, bbLocation, initialCallMadeThisCycle, TwoState);
 
                         const mlir::Value inputFifoRden0 =
                             circt::comb::AndOp::create(opb, bbLocation, stageValid0, initCallNotThisCycle, TwoState);
@@ -8853,7 +8853,7 @@ private:
                     else
                     {
                         const mlir::Value inputFifoNotEmpty = circt::comb::createOrFoldNot(
-                            bbLocation, _compileContext.PortNameToValue("input_fifo_empty_0"), opb, TwoState);
+                            opb, bbLocation, _compileContext.PortNameToValue("input_fifo_empty_0"), TwoState);
 
                         result._startNewThread =
                             circt::comb::AndOp::create(opb, bbLocation, allowNewThread, inputFifoNotEmpty, TwoState);
@@ -8872,7 +8872,7 @@ private:
             {
                 // Inverted because a value of "0" in controlStateRecords means that everything is OK
                 const mlir::Value noUnderflow = circt::comb::createOrFoldNot(
-                    bbLocation, _compileContext.PortNameToValue("input_fifo_underflow_" + std::to_string(i)), opb,
+                    opb, bbLocation, _compileContext.PortNameToValue("input_fifo_underflow_" + std::to_string(i)),
                     TwoState);
 
                 controlStateRecords[ControlStateBit::InputFifoUnderflow].push_back(noUnderflow);
@@ -8906,7 +8906,7 @@ private:
                     const mlir::Value reduced = circt::comb::AndOp::create(opb, bbLocation, expressions, TwoState);
 
                     // Flip bits so that 0 means everything is OK, 1 means something is causing a slow down
-                    controlStateBits[bitIndex] = circt::comb::createOrFoldNot(bbLocation, reduced, opb, TwoState);
+                    controlStateBits[bitIndex] = circt::comb::createOrFoldNot(opb, bbLocation, reduced, TwoState);
                 }
 
                 // Reverse control state bits because concat op expects most significant bit first
@@ -12041,7 +12041,7 @@ private:
 
             if (reversePredicateMeaning)
             {
-                predicate = circt::comb::createOrFoldNot(opLocation, predicate, opb, TwoState);
+                predicate = circt::comb::createOrFoldNot(opb, opLocation, predicate, TwoState);
             }
 
             result = circt::comb::AndOp::create(opb, opLocation, enable, predicate, TwoState);


### PR DESCRIPTION
Bumps the vendored CIRCT submodule from a0b58cc (ESIRuntime-0.2.4) to d8bbbc6 (current main).

Adapts the compiler to upstream API renames:
- comb::createOrFoldNot: arg order changed to (builder, loc, value, twoState)
- comb::createOrFoldSExt: arg order changed to (builder, loc, value, type)
- sv::create{HWCleanup,HWLegalizeModules,PrettifyVerilog}Pass dropped the trailing 'Pass' suffix

Assisted-by: Claude Opus 4.7